### PR TITLE
Check if working vod is unlisted

### DIFF
--- a/text.py.example
+++ b/text.py.example
@@ -23,6 +23,8 @@ def get_private_check_text(status, video_id=None):
         return "[{video_id}](https://youtu.be/{video_id}) requires login to watch on [{channel_name}](https://www.youtube.com/channel/{channel_id})."
     elif status is utils.PlayabilityStatus.OFFLINE: # Should not be here though. But I do dumb things.
         return "[{video_id}](https://youtu.be/{video_id}) offlined on [{channel_name}](https://www.youtube.com/channel/{channel_id})."
+    elif status is utils.PlayabilityStatus.UNLISTED:
+        return "[{video_id}](https://youtu.be/{video_id}) is unlisted on [{channel_name}](https://www.youtube.com/channel/{channel_id})."
     else:
         return "[{video_id}](https://youtu.be/{video_id}) occurred sth very weird on [{channel_name}](https://www.youtube.com/channel/{channel_id})."
 

--- a/utils.py
+++ b/utils.py
@@ -40,6 +40,7 @@ class PlayabilityStatus(Enum):
     ON_LIVE = auto()
     UNKNOWN = auto()
     LOGIN_REQUIRED = auto()
+    UNLISTED = auto()
 
 
 class RepeatedTimer(object):
@@ -235,6 +236,8 @@ def get_video_status(video_id):
             elif '"status":"ERROR"' in html:
                 return PlayabilityStatus.REMOVED
             elif '"status":"OK"' in html:
+                if '"isUnlisted":true' in html:
+                    return PlayabilityStatus.UNLISTED
                 if 'hlsManifestUrl' in html:
                     return PlayabilityStatus.ON_LIVE
                 return PlayabilityStatus.OK


### PR DESCRIPTION
Added `UNLISTED` to the `PlayabilityStatus`. Now the text.py.example has a return message in the `elif` of when the status is unlisted. In the utils.py, when the status is ok, check if the video is unlisted before checking if it is live(before looking for `hlsManifestUrl`). In essence, this allows for the checking of the working vod, and seeing if it has been unlisted. Could later extend to check if member vod has been unlisted but is not implemented in this pull request.