### PR TITLE
Catch jsonDecodeError 

### DIFF
--- a/index.py
+++ b/index.py
@@ -68,7 +68,12 @@ def save():
 
 if os.path.isfile(const.FETCHED_JSON):
     with open(const.FETCHED_JSON, encoding="utf8") as f:
-        fetched = json.load(f)
+        try:
+            fetched = json.load(f)
+        except ValueError as j:
+            print(j)
+            fetched = {}
+            save()
 else:
     fetched = {}
     save()


### PR DESCRIPTION
Catch jsonDecodeError when the fetched.json becomes empty and reset the file with an empty json object to prevent the program from crashing.